### PR TITLE
fix(component-treeState)

### DIFF
--- a/packages/widgets/lib/src/elements/widgets/component.dart
+++ b/packages/widgets/lib/src/elements/widgets/component.dart
@@ -41,8 +41,9 @@ class _OpenWComponentState extends State<OpenWComponent> {
     const NodeRendering nodeRendering = NodeRendering();
     final widget0 = nodeRendering.renderTree(componentChildren);
     final globalState = context.watch<TreeState>();
-    return ChangeNotifierProvider<TreeState>.value(
-      value: globalState.copyWith(
+    return ChangeNotifierProvider(
+      key: UniqueKey(),
+      create: (_) => globalState.copyWith(
           nodeComponentID: widget.state.node.id,
           fit: widget0.getAttributes[DBKeys.componentFit] == 'absolute'
               ? ComponentFit.absolute

--- a/packages/widgets/lib/src/elements/widgets/component.dart
+++ b/packages/widgets/lib/src/elements/widgets/component.dart
@@ -41,9 +41,8 @@ class _OpenWComponentState extends State<OpenWComponent> {
     const NodeRendering nodeRendering = NodeRendering();
     final widget0 = nodeRendering.renderTree(componentChildren);
     final globalState = context.watch<TreeState>();
-
-    return ChangeNotifierProvider(
-      create: (_) => globalState.copyWith(
+    return ChangeNotifierProvider<TreeState>.value(
+      value: globalState.copyWith(
           nodeComponentID: widget.state.node.id,
           fit: widget0.getAttributes[DBKeys.componentFit] == 'absolute'
               ? ComponentFit.absolute


### PR DESCRIPTION
# Pull Request Template

## Description

The globalState.copyWith method in the widget tree was not working properly because the ChangeNotifierProvider was repeated several times.
fix(https://github.com/buildwiththeta/buildwiththeta/issues/252)

## Related Issue(s)

If there is an open issue related to this pull request, please provide a link to it here.

## Screenshots

If your changes affect the app's UI or UX, please provide screenshots or GIFs of the before and after states.

## Checklist

Please ensure that you have completed the following items before submitting this pull request:

- [ ] Code is written in compliance with the project's coding standards.
- [ ] Code has been tested and documented.
- [ ] New and/or updated unit tests have been written.
- [ ] All existing unit tests pass successfully.
- [ ] The app runs successfully on Web (Chrome).
- [ ] Commit messages are clear and concise.

## Additional Information

Is there any additional information that you would like to provide about this pull request? For example, does it address a specific problem or improve a particular aspect of the app's functionality?

## License

By submitting this pull request, you agree to license your contributions under the project's Apache 2.0 license.
